### PR TITLE
Add module entrypoint (FtypeAudit.psm1) for loading core functionality

### DIFF
--- a/src/FtypeAudit.psm1
+++ b/src/FtypeAudit.psm1
@@ -1,0 +1,18 @@
+# src/FtypeAudit.psm1
+
+# ── Platform Utilities ───────────────────────────────
+. "$PSScriptRoot\platform\PlatformContext.ps1"
+
+# ── Core Modules ─────────────────────────────────────
+. "$PSScriptRoot\core\Diagnosis.ps1"
+. "$PSScriptRoot\core\Snapshot.ps1"
+. "$PSScriptRoot\core\Reporter.ps1"
+. "$PSScriptRoot\core\Repair.ps1"
+. "$PSScriptRoot\core\RegistryHelpers.ps1"
+
+# ── Export Public API ────────────────────────────────
+Export-ModuleMember -Function `
+    Get-AssociationSnapshot,
+    Test-AssociationHealth,
+    Write-AssociationReport,
+    Repair-Association

--- a/src/ftype-audit.ps1
+++ b/src/ftype-audit.ps1
@@ -97,7 +97,6 @@ if ($AuditPython -and $PSCmdlet.ParameterSetName -ne '') {
     exit 1
 }
 
-#end region
 
 # ─────────────────────────────────────────────
 # Utility helpers (safe to reuse anywhere)


### PR DESCRIPTION
### Summary

This PR introduces `FtypeAudit.psm1`, which acts as the module entrypoint for `ftype-audit-safe`.

It dot-sources all internal scripts (`core/*` and `platform/PlatformContext.ps1`) and exports key public functions:
- `Get-AssociationSnapshot`
- `Test-AssociationHealth`
- `Write-AssociationReport`
- `Repair-Association`

### Why

This enables future module usage via `Import-Module`, improves modularity, and prepares the project for possible manifest packaging.

No changes to core logic.

---

Resolves part of: modularization initiative.