### PR TITLE
Added Snaphot Tests

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$Path = 'tests'
+)
+
 $requiredVersion = [Version]"5.0"
 $active = (Get-Module Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1)
 
@@ -8,6 +12,7 @@ if ($active.Version -lt $requiredVersion) {
 Import-Module Pester -RequiredVersion $active.Version
 
 $config = New-PesterConfiguration
-$config.Run.Path = 'tests'
+$config.Run.Path = $Path
 $config.Output.Verbosity = 'Detailed'
+
 Invoke-Pester -Configuration $config

--- a/tests/snapshot.tests.ps1
+++ b/tests/snapshot.tests.ps1
@@ -1,0 +1,87 @@
+# tests/snapshot.tests.ps1
+
+Describe "Get-AssociationSnapshot" {
+    BeforeAll {
+        # Import the module/script that contains the class definition and function
+        . (Join-Path $PSScriptRoot '../src/core/Snapshot.ps1')
+    }
+
+    Context "When no registry keys exist" {
+        BeforeEach {
+            Mock Test-Path          { $false }
+            Mock Get-ItemProperty   { }  # Return nothing/null
+            Mock Get-Item           { throw [System.Management.Automation.ItemNotFoundException]::new("Cannot find path") }
+        }
+
+        It "Returns an AssociationSnapshot object with default values" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            $snap.GetType().Name | Should -Be 'AssociationSnapshot'
+            $snap.Extension        | Should -Be '.txt'
+            $snap.RegistryValues.UserChoice    | Should -BeNullOrEmpty
+            $snap.RegistryValues.SystemDefault | Should -BeNullOrEmpty
+            $snap.RegistryValues.OpenWithList  | Should -BeNullOrEmpty
+            $snap.HasData        | Should -BeFalse
+        }
+    }
+
+    Context "When registry keys are present" {
+        BeforeEach {
+            Mock Test-Path {
+                param($path) 
+                return $true
+            }
+            Mock Get-ItemProperty {
+                param($path)
+                if ($path -like '*OpenWithList*') {
+                    return [PSCustomObject]@{ a = 'handler1'; b = 'handler2' }
+                }
+                else {
+                    return [PSCustomObject]@{ ProgId = 'txtfile' }
+                }
+            }
+            Mock Get-Item {
+                param($path)
+                # Create a proper mock object with a ScriptMethod
+                $mockKey = New-Object PSObject
+                $mockKey | Add-Member -MemberType ScriptMethod -Name GetValue -Value { 
+                    param($name) 
+                    return 'sysfile' 
+                }
+                return $mockKey
+            }
+        }
+
+        It "Populates UserChoice with ProgId" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            $snap.RegistryValues.UserChoice.ProgId | Should -Be 'txtfile'
+        }
+
+        It "Populates SystemDefault from default value" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            $snap.RegistryValues.SystemDefault | Should -Be 'sysfile'
+        }
+
+        It "Populates OpenWithList entries" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            $snap.RegistryValues.OpenWithList.a | Should -Be 'handler1'
+            $snap.RegistryValues.OpenWithList.b | Should -Be 'handler2'
+        }
+
+        It "Sets HasData to true when any key is found" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            $snap.HasData | Should -BeTrue
+        }
+    }
+
+    Context "Extension normalization and timestamp" {
+        It "Normalizes extension to lowercase" {
+            $snap = Get-AssociationSnapshot -Extension '.MD'
+            $snap.Extension | Should -Be '.md'
+        }
+
+        It "Sets LastChecked to a time within the last minute" {
+            $snap = Get-AssociationSnapshot -Extension .txt
+            ($snap.LastChecked -gt (Get-Date).AddMinutes(-1)) | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION
# Add Snapshot Tests

## Overview
This PR adds comprehensive unit tests for the `Get-AssociationSnapshot` function, which is a core component of the file type association auditing system.

## Changes Made

### New Files
- **`tests/snapshot.tests.ps1`** - Complete test suite for `Get-AssociationSnapshot` function with 7 test cases

### Modified Files
- **`test.ps1`** - Updated to support running the new snapshot tests

## Test Coverage

The new test suite covers three main scenarios:

### 1. When No Registry Keys Exist
- ✅ Returns an `AssociationSnapshot` object with correct type
- ✅ Sets default values for all properties
- ✅ Handles missing registry keys gracefully

### 2. When Registry Keys Are Present
- ✅ Populates `UserChoice` with `ProgId` from user-level registry
- ✅ Populates `SystemDefault` from HKCR default value
- ✅ Populates `OpenWithList` entries from user-level registry
- ✅ Sets `HasData` to `true` when registry data is found

### 3. Extension Normalization and Timestamp
- ✅ Normalizes extension input to lowercase (e.g., `.MD` → `.md`)
- ✅ Sets `LastChecked` timestamp within expected time range

## Technical Details

### Test Architecture
- Uses **Pester v5** testing framework
- Implements proper **mocking** of registry access functions (`Test-Path`, `Get-ItemProperty`, `Get-Item`)
- Handles **PowerShell class scoping** issues by loading the source file in `BeforeAll`
- Uses **type name comparison** instead of direct type assertions to avoid parse-time issues

### Mock Strategy
The tests mock all registry access to ensure:
- Tests run consistently regardless of actual system registry state
- No dependencies on specific registry keys being present
- Controlled test scenarios for both success and failure cases

### Key Technical Solutions
1. **Class Loading**: Resolved PowerShell class visibility by dot-sourcing in `BeforeAll`
2. **Type Assertions**: Used `$object.GetType().Name` comparison instead of `Should -BeOfType` to avoid parse-time type resolution
3. **Registry Mocking**: Created proper mock objects with `ScriptMethod` for `GetValue()` calls

## Running the Tests

```powershell
# Run all snapshot tests
./test.ps1 -Path tests/snapshot.tests.ps1

# Run all tests
./test.ps1
```

## Quality Assurance

- ✅ All 7 tests pass
- ✅ No dependencies on system state
- ✅ Comprehensive coverage of success and failure scenarios
- ✅ Proper error handling validation
- ✅ Clean separation of concerns with mocking

## Future Considerations

This test foundation enables:
- **Safe refactoring** of the `Get-AssociationSnapshot` function
- **Regression detection** for future changes
- **Documentation** of expected behavior through test cases
- **Confidence** in registry handling edge cases

The test suite follows established patterns that can be extended for other components in the ftype-audit-safe project.